### PR TITLE
Change HS (haplotype) field from Integer to character in VCFs heterog…

### DIFF
--- a/heterogenesis_varincorp.py
+++ b/heterogenesis_varincorp.py
@@ -146,7 +146,7 @@ def main():
             file.write('##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">\n')
             file.write('##FORMAT=<ID=AF,Number=A,Type=Float,Description="Alt allele frequency">\n')
             file.write('##FORMAT=<ID=TC,Number=1,Type=Integer,Description="Total copies of alt allele">\n')
-            file.write('##FORMAT=<ID=HS,Number=1,Type=Integer,Description="Haplotypes">\n')
+            file.write('##FORMAT=<ID=HS,Number=1,Type=Character,Description="Haplotypes">\n')
             file.write('##FORMAT=<ID=HC,Number=.,Type=Integer,Description="Total copies of alt allele per haplotype">\n')
             file.write('##FORMAT=<ID=CN,Number=2,Type=Integer,Description="Copy number at position">\n')
             file.write('#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t'+clo+'\n')


### PR DESCRIPTION
…enesis_varincorp.py

Haplotypes are represented by the HS field in the VCFs generated by Heterogenesis, and are indicated by letters A, B . .  Currently, the VCF header specifies that this field is numeric.  This causes certain VCF parsers to fail to correctly read the HS field.